### PR TITLE
作者別アーカイブのヘッダーに意図しないスタイルがあたっていたのを修正 #28

### DIFF
--- a/src/scss/templates/_main.scss
+++ b/src/scss/templates/_main.scss
@@ -9,7 +9,7 @@ article.hentry, article.error404 {
      margin-bottom: 48px;
    }
 }
-.entry,.page {
+.entry {
   &-header{
     background: $color-gray;
     padding-top: 26px;
@@ -120,6 +120,17 @@ footer.entry-meta{
     @include mq-only-small() {
       text-align: left;
       font-size: 16px;
+    }
+  }
+}
+
+.error-404 {
+  .page {
+    &-header {
+      @extend .entry-header;
+    }
+    &-content {
+      @extend .entry-content;
     }
   }
 }


### PR DESCRIPTION
404ページ用に適用していたスタイルが、作者別アーカイブなどのヘッダーにもあたってしまっていたのが原因です。

404ページのスタイルは、`.error-404`内でのみ当たるよう修正しました。

作者別アーカイブ
![author_archive](https://user-images.githubusercontent.com/1048112/41847014-9499a534-78b3-11e8-8781-96edeb7c1274.png)

404ページ
![404](https://user-images.githubusercontent.com/1048112/41847204-221d66d4-78b4-11e8-9708-684e2d92044f.png)

