### PR TITLE
作者別アーカイブのヘッダーに意図しないスタイルがあたっていたのを修正 #28

### DIFF
--- a/src/scss/templates/_main.scss
+++ b/src/scss/templates/_main.scss
@@ -9,7 +9,7 @@ article.hentry, article.error404 {
      margin-bottom: 48px;
    }
 }
-.entry,.page {
+.entry{
   &-header{
     background: $color-gray;
     padding-top: 26px;
@@ -104,12 +104,15 @@ footer.entry-meta{
   margin: auto;
 }
 
-.page {
+.page{
   &-header {
     padding: 32px 0 34px;
     text-align: center;
+    .error-404 & {
+      @extend .entry-header;
+    }
   }
-  &-title {
+  &-title{
     color: $color-yellow;
     font-weight: bold;
     font-size: 24px;
@@ -121,5 +124,8 @@ footer.entry-meta{
       text-align: left;
       font-size: 16px;
     }
+  }
+  &-content{
+    @extend .entry-content;
   }
 }


### PR DESCRIPTION
404ページ用に適用していたスタイルが、作者別アーカイブなどのヘッダーにもあたってしまっていたのが原因です。

404ページのヘッダースタイルは、`.error-404 .page-header`内でのみ当たるよう修正しました。

