### PR TITLE
#47 チャットスタイルUIのスタイルを追加

### DIFF
--- a/src/scss/components/_chat.scss
+++ b/src/scss/components/_chat.scss
@@ -1,0 +1,76 @@
+.chat {
+  &-body {
+    margin: 24px 0;
+  }
+  &-message {
+    margin-bottom: 32px;
+    @include clearfix();
+  }
+  &-main {
+    position: relative;
+    &.left {
+      padding-left: 80px;
+      float: left;
+    }
+    &.right {
+      padding-right: 80px;
+      float: right;
+    }
+  }
+  &-pics {
+    width: 60px;
+    height: 60px;
+    position: absolute;
+    top: 0;
+    img {
+      display: block;
+      border-radius: 50%;
+    }
+    .left & {
+      left: 0;
+    }
+    .right & {
+      right: 0;
+    }
+  }
+  &-name {
+    font-size: 14px;
+    font-weight: bold;
+    margin-bottom: 4px;
+    &.left {
+      text-align: left;
+    }
+    &.right {
+      text-align: right;
+    }
+  }
+  &-text {
+    padding: 12px;
+    position: relative;
+    background: $color-gray;
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      border: 18px solid transparent;
+      border-top-width: 0;
+    }
+    &.left {
+      border-radius: 0 8px 8px 8px;
+      &::after {
+        left: -30px;
+        border-right-color: $color-gray;
+        border-right-width: 12px;
+      }
+    }
+    &.right {
+      border-radius: 8px 0 8px 8px;
+      &::after {
+        right: -30px;
+        border-left-color: $color-gray;
+        border-left-width: 12px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
キャプチャを添付します。

<img width="654" alt="2018-08-23 5 56 18" src="https://user-images.githubusercontent.com/1048112/44490442-53be7d00-a699-11e8-9daf-d72a67308782.png">

アバターは、正方形の画像が使用されることを期待した作りです。
正方形でないと、キャプチャのCampロゴのような雰囲気になります。
キャプチャでは、わぷーの画像が背景が透過しているので分かりにくいですが
`border-radius: 50%;`が設定されていますので、勝手に丸い画像になります。

使用する際は、以下のひな形を本文にペーストすることでスタイルが適用されます。

```html
<div class="chat-body">

  <div class="chat-message">
    <div class="chat-name left">名前1</div>
    <div class="chat-main left">
      <div class="chat-pics left">
        <img src="https://2018.tokyo.wordcamp.org/files/2018/06/%E6%B1%BA%E5%AE%9A_%E3%83%95%E3%83%AB%E3%82%AB%E3%83%A9%E3%83%BC%E3%83%AD%E3%83%83%E3%82%AF%E3%82%8F%E3%81%B5%E3%82%9A%E3%83%BC02-275x300.png" alt="">
      </div>
      <div class="chat-text left">
        この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。
      </div>
    </div>
  </div>
  
  <div class="chat-message">
    <div class="chat-name right">名前2</div>
    <div class="chat-main right">
      <div class="chat-pics right">
        <img src="https://wctokyo2018.local/wp-content/themes/wct2018/dist/assets/images/header-brand.png" alt="">
      </div>
      <div class="chat-text right">
        この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。
      </div>
    </div>
  </div>

</div>
```